### PR TITLE
Mention in README that Go 1.7+ is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and run, or used as a library in a regular Go program.
 
 SHENZHEN GO requires:
 
-*   [Go](https://golang.org/)
+*   [Go 1.7+](https://golang.org/)
 *   [Graphviz](http://graphviz.org/)
 *   A web browser (e.g. [Chrome](https://www.google.com/chrome)).
 


### PR DESCRIPTION
Older versions of Go won't work due to 1.7+ features used in the project.

For instance, see https://github.com/google/shenzhen-go/blob/f8afcfa39493d162b2b44cff43ac22cac507e81a/graph/graph.go#L114. `SetIndent` was added to standard library [in 1.7](https://golang.org/doc/go1.7#minor_library_changes).

Resolves #12.